### PR TITLE
replaced yaml.load by yaml.safe_load

### DIFF
--- a/yeadon/human.py
+++ b/yeadon/human.py
@@ -1383,7 +1383,7 @@ Inertia tensor in global frame about human's COM (kg-m^2):
         self.measurementconversionfactor = 0
         # open measurement file
         fid = open(fname, 'r')
-        mydict = yaml.load(fid.read())
+        mydict = yaml.safe_load(fid.read())
         fid.close()
         # loop until all 95 parameters are read in
         for key, val in mydict.items():


### PR DESCRIPTION
yaml.load was deprecated in PyYAML 5.1+ and has now changed the API.
This causes an exception to be raised asking to provide a Loader in the
current release of yeadon.

yaml.safe_load is present in all release of PyYAML and is sufficient for
yeadon's purpose.

For more information, see PyYAML's wiki entry.
[https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation]
